### PR TITLE
fix: typos in documentation files

### DIFF
--- a/layouts/README.md
+++ b/layouts/README.md
@@ -1,3 +1,3 @@
 # Layout
 
-Crate with implementations of different execution trace and constraint layouts for proving Cairo programs. For now only a implements the "plain" and "starknet" layouts.
+Crate with implementations of different execution trace and constraint layouts for proving Cairo programs. For now only it implements the "plain" and "starknet" layouts.


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `a implements` to `it implements`

Please review the changes and let me know if any additional changes are needed.

